### PR TITLE
Remove disco pinmap definition as it will now be in arduino-lmic lib

### DIFF
--- a/longfi-us915/longfi-us915.ino
+++ b/longfi-us915/longfi-us915.ino
@@ -104,10 +104,8 @@ const lmic_pinmap lmic_pins = {
 #include "arduino_lmic_hal_boards.h"
 const lmic_pinmap lmic_pins = *Arduino_LMIC::GetPinmap_Catena4610();
 #elif defined(ARDUINO_DISCO_L072CZ_LRWAN1)
-namespace Arduino_LMIC {
-const HalPinmap_t GetPinmap_Disco_L072cz_Lrwan1();
-}
-const lmic_pinmap lmic_pins = Arduino_LMIC::GetPinmap_Disco_L072cz_Lrwan1();
+#include "arduino_lmic_hal_boards.h"
+const lmic_pinmap lmic_pins = *Arduino_LMIC::GetPinmap_Disco_L072cz_Lrwan1();
 #else
 # error "Unknown target"
 #endif
@@ -285,45 +283,3 @@ void loop() {
     os_runloop_once();
 }
 
-namespace Arduino_LMIC { 
-
-    class HalConfiguration_Disco_L072cz_Lrwan1_t : public HalConfiguration_t
-            {
-    public:
-            enum DIGITAL_PINS : uint8_t
-                    {
-                    PIN_SX1276_NSS = 37,
-                    PIN_SX1276_NRESET = 33,
-                    PIN_SX1276_DIO0 = 38,
-                    PIN_SX1276_DIO1 = 39,
-                    PIN_SX1276_DIO2 = 40,
-                    PIN_SX1276_RXTX = 21,
-                    };
-
-        virtual bool queryUsingTcxo(void) override { return false; };
-            };
-    // save some typing by bringing the pin numbers into scope
-    static HalConfiguration_Disco_L072cz_Lrwan1_t myConfig;
-
-    static const HalPinmap_t myPinmap =
-            {
-            .nss = HalConfiguration_Disco_L072cz_Lrwan1_t::PIN_SX1276_NSS,
-            .rxtx = HalConfiguration_Disco_L072cz_Lrwan1_t::PIN_SX1276_RXTX, 
-            .rst = HalConfiguration_Disco_L072cz_Lrwan1_t::PIN_SX1276_NRESET,
-
-            .dio = {HalConfiguration_Disco_L072cz_Lrwan1_t::PIN_SX1276_DIO0, 
-                    HalConfiguration_Disco_L072cz_Lrwan1_t::PIN_SX1276_DIO1, 
-                    HalConfiguration_Disco_L072cz_Lrwan1_t::PIN_SX1276_DIO2, 
-                },
-            .rxtx_rx_active = 1,
-            .rssi_cal = 10,
-            .spi_freq = 8000000,     /* 8MHz */
-            .pConfig = &myConfig
-            };
-
-    const HalPinmap_t GetPinmap_Disco_L072cz_Lrwan1(void)
-            {
-            return myPinmap;
-            }
-
-}; // end namespace Arduino_LMIC


### PR DESCRIPTION
Confirmed working on Disco and Catena 4610 with arduino-lmic master.