### PR TITLE
Update to support LMIC v3.1.0

### DIFF
--- a/longfi-us915/longfi-us915.ino
+++ b/longfi-us915/longfi-us915.ino
@@ -106,10 +106,7 @@ const lmic_pinmap lmic_pins = {
 #include "arduino_lmic_hal_boards.h"
 const lmic_pinmap lmic_pins = *Arduino_LMIC::GetPinmap_Catena4610();
 #elif defined(ARDUINO_DISCO_L072CZ_LRWAN1)
-namespace Arduino_LMIC {
-const HalPinmap_t GetPinmap_Disco_L072cz_Lrwan1();
-}
-const lmic_pinmap lmic_pins = Arduino_LMIC::GetPinmap_Disco_L072cz_Lrwan1();
+const lmic_pinmap lmic_pins = *Arduino_LMIC::GetPinmap_Disco_L072cz_Lrwan1();
 #else
 #error "Unknown target"
 #endif
@@ -320,7 +317,5 @@ static const HalPinmap_t myPinmap = {
     .rssi_cal = 10,
     .spi_freq = 8000000, /* 8MHz */
     .pConfig = &myConfig};
-
-const HalPinmap_t GetPinmap_Disco_L072cz_Lrwan1(void) { return myPinmap; }
 
 }; // end namespace Arduino_LMIC


### PR DESCRIPTION
Looks like the upstream adruino library [released v3.1.0][v310] two weeks ago.

From [the changeset][changes], this includes Helium patches that add the pinmap
for `Disco_L072cz_Lrwan1`. Unfortunately, that means that when this code compiles,
it now throws duplicate symbol errors. This simply removes the now redundant
definition and fixes the type where needed to match upstream.

Verified end-to-end data works with this fix:
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/339422/75085202-88ec9b00-54db-11ea-8db1-e3a47799c9f1.png">


[v310]: https://github.com/mcci-catena/arduino-lmic/releases/tag/v3.1.0
[changes]: https://github.com/mcci-catena/arduino-lmic/compare/3b9b02d..79accbb